### PR TITLE
certbot and nginx agreement

### DIFF
--- a/nginx/docker-compose.yml
+++ b/nginx/docker-compose.yml
@@ -14,8 +14,8 @@ services:
   certbot:
     image: certbot/certbot:latest
     volumes:
-      - ./letsencrypt/:/var/www/certbot/:rw
-      - ./certbot/conf/:/etc/letsencrypt/:rw
+      - ../../certbot/www:/var/www/certbot/:rw
+      - ../../certbot/conf/:/etc/letsencrypt/:rw
     networks:
       - mischaikow-home
 


### PR DESCRIPTION
Turns out, if the Docker volumes are looking in different places for certifications, they won't work!

Fixed this.