### PR TITLE
Roll back pyodide

### DIFF
--- a/src/scripts/scoundrel_webworker.ts
+++ b/src/scripts/scoundrel_webworker.ts
@@ -1,4 +1,4 @@
-import { loadPyodide } from 'https://cdn.jsdelivr.net/pyodide/v0.27.2/full/pyodide.mjs';
+import { loadPyodide } from 'https://cdn.jsdelivr.net/pyodide/v0.27.0/full/pyodide.mjs';
 
 interface GameState {
   room: number;


### PR DESCRIPTION
Appears that Pyodide 27.1+ has problems on Safari in iOS - so trying to downgrade to see if that fixes it. See bug report below for more details.

https://github.com/pyodide/pyodide/issues/5428